### PR TITLE
Fix: [CONFIG] Header branding is ignoring system environment variables use branch nodejs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,11 @@ import Dashboard from './Dashboard';
 import ProductList from './ProductList';
 
 function App() {
+  const appName = import.meta.env.VITE_APP_NAME || 'Default App Name';
   return (
     <div className="App" style={{ padding: '20px' }}>
       <header style={{ marginBottom: '40px', borderBottom: '1px solid rgba(255,255,255,0.1)', paddingBottom: '20px' }}>
-        {/* BUG #3: Hardcoded text instead of import.meta.env.VITE_APP_NAME */}
-        <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>SQUAD_LEGACY</h1>
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>{appName}</h1>
       </header>
       
       <div className="main-content" style={{ display: 'grid', gridTemplateColumns: 'minmax(300px, 400px) 1fr', gap: '40px', alignItems: 'start' }}>


### PR DESCRIPTION
## 🤖 Automated Fix for Issue #33

### Original Issue
Observed Behavior: The main App Header is currently showing the hardcoded text 'SQUAD_LEGACY'. Expected Behavior: It should dynamically display the value from VITE_APP_NAME defined in our .env file. Action: Update App.jsx to use import.meta.env.VITE_APP_NAME.


### Fix Summary
To address the bug described in the issue, we need to update the `App.jsx` file to use the `import.meta.env.VITE_APP_NAME` for displaying the app name instead of the hardcoded text 'SQUAD_LEGACY'. We will also add a fallback mechanism to handle cases where `VITE_APP_NAME` might be empty or not defined.

### Step-by-Step Analysis of the Problem:
1. **Identify the hardcoded text**: The `App.jsx` file currently contains a hardcoded header title 'SQUAD_LEGACY'.
2. **Understand the requirement**: The header title should dynamically display the value from `import.meta.env.VITE_APP_NAME`.
3. **Consider edge cases**: We need to handle scenarios where `import.meta.env.VITE_APP_NAME` might be empty or not defined.

### Fixed Solution:
```jsx
// src/App.jsx
import React from 'react';
import Login from './Login';
import Dashboard from './Dashboard';
import ProductList from './ProductList';

function App() {
  const appName = import.meta.env.VITE_APP_NAME || 'Default App Name';
  return (
    <div 

### QA Validation
# QA Evidence Summary

## Executive Summary
The bug fix for the header branding issue in the App.jsx file has been analyzed and verified. The fix updates the hardcoded text 'SQUAD_LEGACY' to use `import.meta.env.VITE_APP_NAME` with a fallback mechanism to 'Default App Name' if the environment variable is empty or not defined.

**Test Results:**
- **Developer Unit Test (Implementation Check):** PASSED 
- **QA Acceptance Test (Playwright DOM (Chromium)):** FAILED due to a timeout error
- **Existing Test Suite (`npm test`):** FAILED due to a missing script

## What was Fixed and How it Addresses the Bug
The fix replaces the hardcoded text 'SQUAD_LEGACY' in the App.jsx file with `import.meta.env.VITE_APP_NAME || 'Default App Name'`. This change allows the app name to be dynamically retrieved from the environment variable `VITE_APP_NAME` defined in the .env file. If `VITE_APP_NAME` is empty or not defined, it falls back to 'Default App Name'.

## Test Evidence
### Developer Unit Test (Imple

---
**Branch:** `fix/issue-33-config-header-branding-is-igno-6c28dd` → `nodejs`
**Generated by:** Bug Resolution Squad
**Resolves:** #33
