### PR TITLE
Fix: [CRITICAL] Dashboard crashes during initial data fetch use branch nodejs

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -2,13 +2,19 @@ import React, { useState, useEffect } from 'react';
 
 const Dashboard = () => {
   const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     // Simulating API fetch
     setTimeout(() => {
       setData({ users: 44, uptime: '99.9%' });
+      setIsLoading(false); // Set isLoading to false after data is fetched
     }, 1000);
   }, []);
+
+  if (isLoading) {
+    return <div>Loading...</div>; // Render "Loading..." while data is being fetched
+  }
 
   return (
     <div className="dashboard-card" style={{ marginTop: '20px', padding: '20px', background: 'rgba(255,255,255,0.05)', borderRadius: '12px' }}>


### PR DESCRIPTION
## 🤖 Automated Fix for Issue #37

### Original Issue
Observed Behavior: The application goes blank (White Screen of Death) as soon as the Dashboard loads. Error: TypeError: Cannot read properties of null (reading 'users'). Root Cause: The component tries to render data.users before the useEffect fetch completes. Action: Implement a loading guard or use optional chaining (data?.users) in Dashboard.jsx.

### Fix Summary
To address the bug described in the issue, we need to prevent the component from trying to access `data.users` before the data is fetched. The most straightforward approach is to introduce a loading state and conditionally render a "Loading..." message while the data is being fetched.

### Step-by-Step Analysis of the Problem:
1. **Identify the Root Cause**: The component tries to render `data.users` before the data is fetched, causing a `TypeError: Cannot read properties of null (reading 'users')`.
2. **Assess the Current Code**: The current code does not handle the case where `data` is `null` before the fetch completes.
3. **Determine the Minimal Fix**: Introduce a loading state (`isLoading`) to track whether the data is being fetched and conditionally render a "Loading..." message.

### Fixed Solution:
```jsx
import React, { useState, useEffect } from 'react';

const Dashboard = () => {
  const [data, setData] = useState(null);
  const [isLoading, setIsLoading] = useState(true);

  

### QA Validation
# QA Evidence Summary

## Executive Summary
The bug fix for the dashboard crashing during initial data fetch was analyzed and validated. The fix introduces a loading guard to prevent rendering data before it is fetched, directly addressing the root cause of the bug. However, some issues were identified during the validation process.

**Test Results:**
- **Developer Unit Test:** PASSED ✅
- **QA Acceptance Test:** FAILED ❌
- **Existing Test Suite (`npm test`):** FAILED ❌

## What was Fixed and How it Addresses the Bug
The fix introduces a loading state (`isLoading`) to track whether the data is being fetched. It conditionally renders a "Loading..." message while `isLoading` is `true`, preventing the component from trying to access `data.users` before the data is fetched. This directly addresses the root cause of the bug, which was a `TypeError: Cannot read properties of null (reading 'users')`.

## Test Evidence
The test evidence includes:
- **Developer Unit Test Output:** 
  ```
  File 

---
**Branch:** `fix/issue-37-critical-dashboard-crashes-dur-63df04` → `nodejs`
**Generated by:** Bug Resolution Squad
**Resolves:** #37
