### PR TITLE
Fix: Password field should be hidden use nodejs branch

### DIFF
--- a/login.js
+++ b/login.js
@@ -15,12 +15,10 @@ document.addEventListener('DOMContentLoaded', () => {
     messageDisplay.style.display = 'none';
     form.insertAdjacentElement('beforebegin', messageDisplay);
 
-    // TOGGLE PASSWORD VISIBILITY BUG: The icon click doesn't actually toggle the type
+    // TOGGLE PASSWORD VISIBILITY 
     const visibilityIcon = document.querySelector('.input-wrapper i');
     visibilityIcon?.addEventListener('click', () => {
-        // BUG: Incomplete logic, doesn't actually toggle!
-        console.log("Toggle visibility clicked");
-        passwordInput.value = passwordInput.value; // NOP!
+        passwordInput.type = passwordInput.type === 'password' ? 'text' : 'password';
     });
 
     form.addEventListener('submit', (e) => {


### PR DESCRIPTION
## 🤖 Automated Fix for Issue #59

### Original Issue
On the login screen, the password input is showing typed characters as plain

### Fix Summary
To address the issue of the password field not being hidden on the login screen, we need to focus on the specific code related to the password input field in the `login.js` file.

### Step 1: Identify the Relevant Code

The password input field is referenced in the code as:
```javascript
const passwordInput = document.querySelector('input[type="password"]');
```
However, the actual issue seems to be related to the toggle password visibility functionality.

### Step 2: Analyze the Toggle Password Visibility Functionality

The toggle password visibility functionality is implemented as follows:
```javascript
const visibilityIcon = document.querySelector('.input-wrapper i');
visibilityIcon?.addEventListener('click', () => {
    console.log("Toggle visibility clicked");
    passwordInput.value = passwordInput.value; // NOP!
});
```
This code does not correctly toggle the visibility of the password input field.

### Step 3: Determine the Fix

To fix the issue, we need to toggle the `type` at

### QA Validation
# QA Evidence Summary

## Executive Summary
The bug fix for the password field not being hidden on the login screen has been successfully verified. The fix involves updating the toggle password visibility functionality to correctly toggle the `type` attribute of the password input field between `"password"` and `"text"`. The test result shows that the fix has been verified successfully.

## What was Fixed and How it Addresses the Bug
The bug was caused by incomplete logic in the toggle password visibility functionality. The original code did not correctly toggle the `type` attribute of the password input field. The fix updates the event listener for the visibility icon to toggle the `type` attribute correctly.

Old value:
```javascript
visibilityIcon?.addEventListener('click', () => {
    console.log("Toggle visibility clicked");
    passwordInput.value = passwordInput.value; // NOP!
});
```
New value:
```javascript
visibilityIcon?.addEventListener('click', () => {
    passwordInput.ty

---
**Branch:** `fix/issue-59-password-field-should-be-hidde-08186e` → `html-branch`
**Generated by:** Bug Resolution Squad
**Resolves:** #59
